### PR TITLE
added small alert under API token field

### DIFF
--- a/src/pages/SettingsPage/SettingRegions/SettingRegionAPI.tsx
+++ b/src/pages/SettingsPage/SettingRegions/SettingRegionAPI.tsx
@@ -53,7 +53,10 @@ export const SettingRegionAPI: FC = () => {
 				</ListSubheader>
 			}
 		>
-			<WrappableListItem primary="Personal access token (classic)">
+			<WrappableListItem
+				primary="Personal access token (classic)"
+				secondary="Without repository permission, the private repositories will be invisible."
+			>
 				<TextField
 					fullWidth
 					placeholder="ghp_"


### PR DESCRIPTION
Under token API field, I added a small alert to notify users that the token should have repository permission, otherwise, it private repositories will be invisible.