### PR TITLE
added option to select sorting order

### DIFF
--- a/src/components/RepoQueryForm.tsx
+++ b/src/components/RepoQueryForm.tsx
@@ -22,11 +22,13 @@ export const RepoQueryForm: FC<
 		setFullName,
 		setStatus,
 		setVisibility,
+		setSortOrder,
 	} = useRepoQueryForm(initQuery);
 	const {
 		statusOptions,
 		visibilityOptions,
 		sortByOptions,
+		sortOrderOptions,
 	} = useRepoQueryOptions();
 	return (
 		<Form replace>
@@ -35,7 +37,7 @@ export const RepoQueryForm: FC<
 				spacing={1}
 			>
 				<Typography fontWeight="bold">
-					Filter
+					Filtering
 				</Typography>
 				<StyledTextField
 					name="fullName"
@@ -66,6 +68,13 @@ export const RepoQueryForm: FC<
 					value={query.sortBy}
 					onChange={setSortBy}
 					options={sortByOptions}
+				/>
+				<StyledSelect
+					label="Order"
+					name="sortOrder"
+					value={query.sortOrder}
+					onChange={setSortOrder}
+					options={sortOrderOptions}
 				/>
 				<StyledIconButton type="submit">
 					<SearchRounded />

--- a/src/core/sorting.ts
+++ b/src/core/sorting.ts
@@ -1,3 +1,4 @@
+import { RepoQuery } from "~types/query";
 import {
 	IssueSchema,
 	RepoSchema,
@@ -12,7 +13,7 @@ export const sortByString = (
 	if (_a + _b !== 2) {
 		return _b - _a;
 	}
-	return b!.localeCompare(a!);
+	return a!.localeCompare(b!);
 };
 
 export const sortByBoolean = (
@@ -78,29 +79,35 @@ export const getIssueSortFn = (
 	return orderFn;
 };
 
-export const getRepoSortFn = (
+const getRepoSortFn = (
 	property: keyof RepoSchema,
 ):
 	| ((a: RepoSchema, b: RepoSchema) => number)
 	| undefined => {
 	switch (property) {
-		case "status":
-		case "visibility":
 		case "fullName":
+			return (a, b) =>
+				sortByString(a[property], b[property]);
 		case "pushedAt":
 		case "createdAt":
 		case "updatedAt":
 			return (a, b) =>
-				sortByString(
-					a[property] as
-						| string
-						| undefined
-						| null,
-					b[property] as
-						| string
-						| undefined
-						| null,
-				);
+				sortByString(b[property], a[property]);
 	}
 	return undefined;
+};
+
+export const sortRepos = (
+	repos: RepoSchema[],
+	query: RepoQuery,
+): void => {
+	const { sortOrder, sortBy } = query;
+	const sortFn = getRepoSortFn(sortBy);
+	if (sortFn === undefined) {
+		return;
+	}
+	repos.sort(sortFn);
+	if (sortOrder === "desc") {
+		repos.reverse();
+	}
 };

--- a/src/hooks/useRepoQueryForm.ts
+++ b/src/hooks/useRepoQueryForm.ts
@@ -39,11 +39,21 @@ export const useRepoQueryForm = (
 			return next;
 		});
 	};
+	const setSortOrder = (
+		value: RepoQuery["sortOrder"],
+	) => {
+		setQuery((prev) => {
+			const next = { ...prev };
+			next["sortOrder"] = value;
+			return next;
+		});
+	};
 	return {
 		query,
 		setFullName,
 		setStatus,
 		setVisibility,
 		setSortBy,
+		setSortOrder,
 	};
 };

--- a/src/hooks/useRepoQueryOptions.ts
+++ b/src/hooks/useRepoQueryOptions.ts
@@ -3,6 +3,19 @@ import { SelectOption } from "~types/generic";
 import { RepoQuery } from "~types/query";
 
 export const useRepoQueryOptions = () => {
+	const { current: sortOrderOptions } = useRef<
+		SelectOption<RepoQuery["sortOrder"]>[]
+	>([
+		{
+			label: "Ascending",
+			value: "asc",
+		},
+		{
+			label: "Descending",
+			value: "desc",
+		},
+	]);
+
 	const { current: visibilityOptions } = useRef<
 		SelectOption<RepoQuery["visibility"]>[]
 	>([
@@ -27,15 +40,15 @@ export const useRepoQueryOptions = () => {
 			value: "fullName",
 		},
 		{
-			label: "Date created",
+			label: "Time since created",
 			value: "createdAt",
 		},
 		{
-			label: "Last updated",
+			label: "Time since last updated",
 			value: "updatedAt",
 		},
 		{
-			label: "Last pushed",
+			label: "Time since last pushed",
 			value: "pushedAt",
 		},
 	]);
@@ -59,5 +72,6 @@ export const useRepoQueryOptions = () => {
 		statusOptions,
 		visibilityOptions,
 		sortByOptions,
+		sortOrderOptions,
 	};
 };

--- a/src/pages/RepoListPage/loader.ts
+++ b/src/pages/RepoListPage/loader.ts
@@ -2,7 +2,7 @@ import { LoaderFunction } from "react-router-dom";
 import { getCachedRepos } from "resources/cached";
 import { filterRepos } from "~core/filtering";
 import { extractRepoQuery } from "~core/query";
-import { sortByString } from "~core/sorting";
+import { sortRepos } from "~core/sorting";
 import { RepoQuery } from "~types/query";
 import { RepoSchema } from "~types/schema";
 
@@ -18,15 +18,8 @@ export const loader: LoaderFunction = async ({
 		searchParams,
 	);
 	const cachedRepos = await getCachedRepos();
-	const repos = filterRepos(
-		cachedRepos,
-		query,
-	).sort((a, b) =>
-		sortByString(
-			b[query.sortBy] as string,
-			a[query.sortBy] as string,
-		),
-	);
+	const repos = filterRepos(cachedRepos, query);
+	sortRepos(repos, query);
 	const loaderData: LoaderData = {
 		repos,
 		query,

--- a/src/resources/settings.ts
+++ b/src/resources/settings.ts
@@ -10,6 +10,7 @@ export const getRepoQueryPreference =
 			status: "active",
 			visibility: "all",
 			sortBy: "fullName",
+			sortOrder: "asc",
 		};
 		try {
 			const jsonString: string = await invoke(

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -8,6 +8,7 @@ export type RepoQueryPref = {
 	status: "all" | "active" | "archived";
 	visibility: "all" | "private" | "public";
 	sortBy: keyof RepoSchema;
+	sortOrder: "asc" | "desc";
 };
 
 export type IssueQuery = IssueQueryPref & {


### PR DESCRIPTION
- added option sort repositories in either ascending or descending order
- adjusted choice of word for sort by select options to improve charity with sort order
- simplifed api in core/sorting, rather than exporting a sorting function, the function selection is kept internal and the exposed function accepts a list of repository objects and a repository query object which is a overkill, but chosen to maintain consistency with core/filtering