### PR TITLE
Removed spinner in update buttons in its busy state

### DIFF
--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -1,7 +1,6 @@
 import {
 	Box,
 	Button,
-	CircularProgress,
 	Stack,
 	Typography,
 } from "@mui/material";
@@ -33,11 +32,9 @@ export const SettingsPage: FC = () => {
 				"Unknown",
 			);
 			const lastUpdatedMsg = `Last updated: ${timeUpdated} (${timeSinceUpdated})`;
-			const buttonText = isBusy ? (
-				<CircularProgress size={24} />
-			) : (
-				label
-			);
+			const buttonText = isBusy
+				? "Working"
+				: label;
 			return (
 				<Box key={`s-${index}`}>
 					<Button


### PR DESCRIPTION
Remove the spinners from loading state of update buttons so I do not have to deal with weird sizing and layout shift cause by it.